### PR TITLE
Implement additional features based on feedback

### DIFF
--- a/activetable.css
+++ b/activetable.css
@@ -66,10 +66,10 @@ input[type="text"] {
     background-color: transparent;
 }
 input[type="text"]:hover {
-    outline: 2px solid #a0a0ff;
+    outline: 3px solid #a0a0ff;
 }
 input[type="text"]:focus {
-    outline: 2px solid #8080ff;
+    outline: 3px solid #8080ff;
 }
 #help {
     display: none;

--- a/activetable.css
+++ b/activetable.css
@@ -20,6 +20,7 @@ tr.odd {
     background-color: #f0f0f0;
 }
 th, td {
+    line-height: 1.5em;
     padding: 5px 10px;
     border: 1px solid #c0c0c0;
 }
@@ -29,9 +30,13 @@ th {
 }
 /* cells that allow user input */
 td.active {
+    padding: 0;
+}
+/* Cells that haven't been checked yet */
+td.unchecked {
     background-color: #ffffe0;
 }
-tr.odd td.active {
+tr.odd td.unchecked {
     background-color: #f0f0d0;
 }
 /* cells containing wrong answers after clicking "Check" */
@@ -50,8 +55,19 @@ tr.odd td.right-answer {
 }
 input[type="text"] {
     font-size: 1em;
+    line-height: 1.5em;
     border: 0;
-    padding: 0 10px;
+    padding: 5px 10px;
     margin: 0;
+    box-sizing: border-box;
+    display: block;
+    width: 100%;
+    height: 100%;
     background-color: transparent;
+}
+input[type="text"]:hover {
+    outline: 2px solid #a0a0ff;
+}
+input[type="text"]:focus {
+    outline: 2px solid #8080ff;
 }

--- a/activetable.css
+++ b/activetable.css
@@ -1,13 +1,14 @@
 body {
     padding: 0;
     margin: 0;
-}
-table {
-    padding: 0;
-    margin: 0;
+    font: normal 1em/1.6em "Open Sans",Verdana,Geneva,sans-serif,sans-serif;
     color: #3c3c3c;
     background-color: #ffffff;
-    font: normal 1em/1.6em "Open Sans",Verdana,Geneva,sans-serif,sans-serif;
+}
+table {
+    clear: both;
+    padding: 0;
+    margin: 0;
     border-collapse: collapse;
 }
 tr {
@@ -69,4 +70,23 @@ input[type="text"]:hover {
 }
 input[type="text"]:focus {
     outline: 2px solid #8080ff;
+}
+#help {
+    display: none;
+}
+#help-text {
+    display: none;
+    padding: 5px 10px;
+    margin: 0 0 10px;
+    border: 1px solid #c0c0c0;
+    background-color: #f0f0f0;
+}
+#help-button {
+    float: right;
+    padding: 6px 10px 0;
+    color: #009fe6;
+    cursor: pointer;
+}
+#help-button:hover {
+    color: #bd9730;
 }

--- a/activetable.css
+++ b/activetable.css
@@ -8,7 +8,6 @@ table {
     color: #3c3c3c;
     background-color: #ffffff;
     font: normal 1em/1.6em "Open Sans",Verdana,Geneva,sans-serif,sans-serif;
-    border: 1px solid #c0c0c0;
     border-collapse: collapse;
 }
 tr {
@@ -22,7 +21,7 @@ tr.odd {
 }
 th, td {
     padding: 5px 10px;
-    border-width: 0;
+    border: 1px solid #c0c0c0;
 }
 th {
     text-align: left;
@@ -54,5 +53,5 @@ input[type="text"] {
     border: 0;
     padding: 0 10px;
     margin: 0;
-    background-color: rgba(0, 0, 0, 0);
+    background-color: transparent;
 }

--- a/activetable.css
+++ b/activetable.css
@@ -21,7 +21,7 @@ tr.odd {
 }
 th, td {
     line-height: 1.5em;
-    padding: 5px 10px;
+    padding: 0 10px;
     border: 1px solid #c0c0c0;
 }
 th {
@@ -57,12 +57,11 @@ input[type="text"] {
     font-size: 1em;
     line-height: 1.5em;
     border: 0;
-    padding: 5px 10px;
+    padding: 0 10px;
     margin: 0;
     box-sizing: border-box;
     display: block;
     width: 100%;
-    height: 100%;
     background-color: transparent;
 }
 input[type="text"]:hover {

--- a/activetable.html
+++ b/activetable.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <link href="activetable.css" rel="stylesheet" type="text/css">
     <script src="activetable.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   </head>
 
   <body>

--- a/activetable.html
+++ b/activetable.html
@@ -4,12 +4,14 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="UTF-8">
     <link href="activetable.css" rel="stylesheet" type="text/css">
+    <style id="row-height-style"></style>
     <script src="activetable.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js"></script>
   </head>
 
   <body>
     <table id="activeTable">
+      <colgroup></colgroup>
       <thead></thead>
       <tbody></tbody>
     </table>

--- a/activetable.html
+++ b/activetable.html
@@ -10,6 +10,10 @@
   </head>
 
   <body>
+    <div id="help">
+      <a id="help-button">+help</a>
+      <p id="help-text"></p>
+    </div>
     <table id="activeTable">
       <colgroup></colgroup>
       <thead></thead>

--- a/activetable.js
+++ b/activetable.js
@@ -39,6 +39,7 @@ var ActiveTable = (function () {
         // complete problem description and the values entered by the student.
         var
             state = [],
+            help_text = $('#help-text').text() || null;
             column_widths = [],
             row_height = parseInt($('tr').css('height'));
 
@@ -66,6 +67,7 @@ var ActiveTable = (function () {
         $('#activeTable colgroup col').each(appendCol);
         return JSON.stringify({
             data: state,
+            help_text: help_text,
             column_widths: column_widths,
             row_height: row_height,
         });
@@ -126,6 +128,18 @@ var ActiveTable = (function () {
             return $row;
         }
 
+        function makeHelp(help_text) {
+            var help_active = false;
+            if (!help_text) return;
+            $('#help-text').text(help_text);
+            $('#help-button').click(function(e) {
+                $('#help-text').toggle();
+                help_active = !help_active;
+                $(this).text(help_active ? '-help' : '+help');
+            });
+            $('#help').show();  // Show the div with the button, not the text.
+        }
+
         function makeColGroup(num_cols, column_widths) {
             var w;
             for (var i = 0; i < num_cols; i++) {
@@ -150,6 +164,7 @@ var ActiveTable = (function () {
             }
             $row.appendTo('#activeTable tbody');
         }
+        makeHelp(state.help_text);
         makeColGroup(state.data[0].length, state.column_widths);
         setRowHeight(state.row_height);
     }

--- a/activetable.js
+++ b/activetable.js
@@ -19,8 +19,8 @@ var ActiveTable = (function () {
 
     // Placeholder strings for the different input types
     placeholder = {};
-    placeholder[NUMERIC] = 'number'
-    placeholder[STRING] = 'answer'
+    placeholder[NUMERIC] = 'numeric response'
+    placeholder[STRING] = 'text response'
 
     function grade(state) {
         // This function attaches correctness information to each input field.

--- a/activetable.js
+++ b/activetable.js
@@ -67,7 +67,7 @@ var ActiveTable = (function () {
         // Classes used on cells that contain input fields, based on their
         // correctness.
         var cell_classes = {}, $row;
-        cell_classes[undefined] = 'active';
+        cell_classes[undefined] = 'unchecked';
         cell_classes[true] = 'right-answer';
         cell_classes[false] = 'wrong-answer';
 
@@ -85,7 +85,11 @@ var ActiveTable = (function () {
                 type: 'text',
                 value: cell_state.value,
                 placeholder: placeholder[cell_state.type],
-                size: '10',
+                // The input will always fill the whole width of the table cell,
+                // but some browsers will use the size value as a minimum, and
+                // assume a default if you don't set the size, so we have to set
+                // it to a small value.
+                size: '1',
             }).data(cell_state);
         }
 
@@ -97,6 +101,7 @@ var ActiveTable = (function () {
                 $cell = $('<td>');
                 $cell.attr('id', 'cell_' + i + '_' + j);
                 if (typeof cell_state === 'object') {
+                    $cell.addClass('active');
                     $cell.addClass(cell_classes[cell_state.correct]);
                     $cell.append(makeInput(cell_state));
                 } else {

--- a/activetable.js
+++ b/activetable.js
@@ -28,8 +28,8 @@ var ActiveTable = (function () {
         // function embedded in XML determines correctness independently of this
         // function.
         $('#activeTable input').each(function() {
-            var $input = $(this), data = $input.data();
-            $input.data('correct', check_response[data.type](data, this.value));
+            var $input = $(this), cell_data = $input.data();
+            $input.data('correct', check_response[cell_data.type](cell_data, this.value));
         });
         return state;
     }
@@ -38,7 +38,7 @@ var ActiveTable = (function () {
         // Extract the current state of the table.  The state includes the
         // complete problem description and the values entered by the student.
         var
-            state = [],
+            data = [],
             help_text = $('#help-text').text() || null;
             column_widths = [],
             row_height = parseInt($('tr').css('height'));
@@ -46,16 +46,16 @@ var ActiveTable = (function () {
         function appendRow() {
             var row_state = [];
             $(this).children().each(function() {
-                var $cell = $(this), $input = $('input', this), data;
+                var $cell = $(this), $input = $('input', this), cell_data;
                 if (typeof $input[0] === 'undefined') {
                     row_state.push($cell.text());
                 } else {
-                    data = $input.data();
-                    data.value = $('input', this)[0].value;
-                    row_state.push(data);
+                    cell_data = $input.data();
+                    cell_data.value = $('input', this)[0].value;
+                    row_state.push(cell_data);
                 }
             });
-            state.push(row_state);
+            data.push(row_state);
         }
 
         function appendCol() {
@@ -66,7 +66,7 @@ var ActiveTable = (function () {
         $('#activeTable tbody tr').each(appendRow);
         $('#activeTable colgroup col').each(appendCol);
         return JSON.stringify({
-            data: state,
+            data: data,
             help_text: help_text,
             column_widths: column_widths,
             row_height: row_height,

--- a/activetable.xml
+++ b/activetable.xml
@@ -171,7 +171,7 @@ column_widths = None
 #column_widths = [150, 150, 150, 150]
 
 # The height of a table row in pixels.  Rows may grow higher than the specified value if the text
-# in some cells in the row is long enough to get wrapped in more than more lines.  If this happens,
+# in some cells in the row is long enough to get wrapped in more than one line.  If this happens,
 # you might need to replace "$height" close to the end of this file by a big enough value to
 # prevent a vertical scrollbar for the iframe from appearing.
 row_height = 36

--- a/activetable.xml
+++ b/activetable.xml
@@ -163,7 +163,7 @@ default_tolerance = 1.0
 # Syntax of the special cell types:
 #
 #     Numeric(answer=<correct_answer>, tolerance=<tolerance in percent>,
-#             min_siginificant_digits=<number>, max_significant_digits=<number>)
+#             min_significant_digits=<number>, max_significant_digits=<number>)
 #         The tolerance is optional, and will default to the default tolerance specified above.
 #         The restrictions for the number of significant digits are optional as well.  Significant
 #         digits are counted started from the first non-zero digit specified by the student, and

--- a/activetable.xml
+++ b/activetable.xml
@@ -54,7 +54,7 @@ class String(ResponseCell):
         return student_response == self.answer
 
 
-def init(table, column_widths, row_height):
+def init(table, help_text, column_widths, row_height):
     """Initialisation code for values exported to the XML code.
 
     The initial_state is a JSON string exported to the JavaScript code and used to construct
@@ -64,7 +64,12 @@ def init(table, column_widths, row_height):
         [cell.get_state() if isinstance(cell, ResponseCell) else str(cell) for cell in row]
         for row in table
     ]
-    initial_state = dict(data=data, column_widths=column_widths, row_height=row_height)
+    initial_state = dict(
+        data=data,
+        help_text=help_text,
+        column_widths=column_widths,
+        row_height=row_height,
+    )
     # Curiously, the JSON string must be doubly HTML-escaped.
     initial_state = json.dumps(initial_state).replace('&', '&amp;amp;').replace('"', '&amp;quot;')
     # All heights and widths include a bit of safety margin to avoid scrollbars and rendering
@@ -74,6 +79,8 @@ def init(table, column_widths, row_height):
     else:
         width = 800 + 2
     height = (row_height + 1) * len(table)
+    if help_text:
+        height += (len(help_text) // 100 + 2) * 26
     return initial_state, width, height
 
 
@@ -153,10 +160,15 @@ table = [
     ['purple', 3.4, 2.1, Numeric(answer=-1.3)],
 ]
 
+# Set the text that gets displayed when clicking the "+help" button.  Use "None" to disable the
+# help feature.
+#help_text = None
+help_text = "Fill in the yellow fields with the right values."
+
 # Set the width of the columns in pixels.  The total width of the table shouldn't be more than 800.
 # You can use "column_width = None" for equal-width columns with a total width of 800 pixels.
 column_widths = None
-# column_widths = [150, 150, 150, 150]
+#column_widths = [150, 150, 150, 150]
 
 # The height of a table row in pixels.  Rows may grow higher than the specified value if the text
 # in some cells in the row is long enough to get wrapped in more than more lines.  If this happens,
@@ -165,7 +177,7 @@ column_widths = None
 row_height = 36
 
 # Initialisation -- don't remove!
-initial_state, width, height = init(table, column_widths, row_height)
+initial_state, width, height = init(table, help_text, column_widths, row_height)
 
 ]]>
 </script>
@@ -181,9 +193,6 @@ initial_state, width, height = init(table, column_widths, row_height)
   version of a problem they've already worked on after a member of staff edited
   the problem.  You can change the problem settings by clicking EDIT above, then
   SETTINGS in the top right corner of the edit window.
-</p>
-<p>
-  Fill in the yellow fields with the right values.
 </p>
 <customresponse cfn="check_table">
   <jsinput gradefn="ActiveTable.grade"

--- a/activetable.xml
+++ b/activetable.xml
@@ -6,6 +6,7 @@
 
 import json
 
+
 class ResponseCell(object):
     """Abstract base class for response cells."""
 
@@ -53,7 +54,7 @@ class String(ResponseCell):
         return student_response == self.answer
 
 
-def init(table):
+def init(table, column_widths, row_height):
     """Initialisation code for values exported to the XML code.
 
     The initial_state is a JSON string exported to the JavaScript code and used to construct
@@ -63,10 +64,17 @@ def init(table):
         [cell.get_state() if isinstance(cell, ResponseCell) else str(cell) for cell in row]
         for row in table
     ]
+    initial_state = dict(data=data, column_widths=column_widths, row_height=row_height)
     # Curiously, the JSON string must be doubly HTML-escaped.
-    initial_state = json.dumps(data).replace('&', '&amp;amp;').replace('"', '&amp;quot;')
-    height = 38 * len(table)  # Includes a bit of safety margin to avoid ugly scrollbars.
-    return initial_state, height
+    initial_state = json.dumps(initial_state).replace('&', '&amp;amp;').replace('"', '&amp;quot;')
+    # All heights and widths include a bit of safety margin to avoid scrollbars and rendering
+    # artifacts on some browsers.
+    if column_widths is not None:
+        width = sum(column_widths) + 2
+    else:
+        width = 800 + 2
+    height = (row_height + 1) * len(table)
+    return initial_state, width, height
 
 
 def check_consistency(state):
@@ -75,9 +83,9 @@ def check_consistency(state):
     If not, the problem was edited in the mean time, and we ask the student to click
     the reset button (as we can't initiate resetting the problem from code).
     """
-    if len(table) != len(state):
+    if len(table) != len(state['data']):
         return False
-    for row, row_state in zip(table, state):
+    for row, row_state in zip(table, state['data']):
         if len(row) != len(row_state):
             return False
         for cell, cell_state in zip(row, row_state):
@@ -109,7 +117,7 @@ def check_table(unused_expect, ans):
         }
 
     correct_answers = total_questions = 0
-    for row, row_state in zip(table, state):
+    for row, row_state in zip(table, state['data']):
         for cell, cell_state in zip(row, row_state):
             if isinstance(cell, ResponseCell):
                 total_questions += 1
@@ -145,8 +153,19 @@ table = [
     ['purple', 3.4, 2.1, Numeric(answer=-1.3)],
 ]
 
+# Set the width of the columns in pixels.  The total width of the table shouldn't be more than 800.
+# You can use "column_width = None" for equal-width columns with a total width of 800 pixels.
+column_widths = None
+# column_widths = [150, 150, 150, 150]
+
+# The height of a table row in pixels.  Rows may grow higher than the specified value if the text
+# in some cells in the row is long enough to get wrapped in more than more lines.  If this happens,
+# you might need to replace "$height" close to the end of this file by a big enough value to
+# prevent a vertical scrollbar for the iframe from appearing.
+row_height = 36
+
 # Initialisation -- don't remove!
-initial_state, height = init(table)
+initial_state, width, height = init(table, column_widths, row_height)
 
 ]]>
 </script>
@@ -171,7 +190,7 @@ initial_state, height = init(table)
     get_statefn="ActiveTable.getState"
     set_statefn="ActiveTable.setState"
     initial_state="$initial_state"
-    width="800"
+    width="$width"
     height="$height"
     html_file="/static/activetable.html"
     sop="true"/>

--- a/activetable.xml
+++ b/activetable.xml
@@ -4,6 +4,7 @@
 # This Python code defines and evaluates the problem. You usually don't need to touch the
 # first portion of the code and can jump to "Problem definition" near the end.
 
+import decimal
 import json
 
 
@@ -24,12 +25,15 @@ class Numeric(ResponseCell):
 
     TYPE = 1
 
-    def __init__(self, answer, tolerance=None):
+    def __init__(self, answer, tolerance=None,
+                 min_significant_digits=None, max_significant_digits=None):
         """Set the correct answer and the allowed relative tolerance in percent."""
         self.answer = answer
         if tolerance is None:
             tolerance = default_tolerance
         self.abs_tolerance = abs(answer) * tolerance / 100.0
+        self.min_significant_digits = min_significant_digits;
+        self.max_significant_digits = max_significant_digits;
 
     def check_response(self, student_response):
         """Return a Boolean value indicating whether the student response is correct."""
@@ -37,6 +41,12 @@ class Numeric(ResponseCell):
             r = float(student_response)
         except ValueError:
             return False
+        if self.min_significant_digits or self.max_significant_digits:
+            d = len(decimal.Decimal(student_response).as_tuple().digits)
+            if self.min_significant_digits and d < self.min_significant_digits:
+                return False
+            if self.max_significant_digits and d > self.max_significant_digits:
+                return False
         return abs(r - self.answer) <= self.abs_tolerance
 
 
@@ -149,8 +159,16 @@ default_tolerance = 1.0
 # be either a string or number, which will simply be shown to the student, or one of the special
 # cell types Numeric() or String(), indicating a numeric or string input field that must be filled
 # in by the student.
+#
 # Syntax of the special cell types:
-#     Numeric(answer=<correct_answer>, tolerance=<tolerance in percent>)
+#
+#     Numeric(answer=<correct_answer>, tolerance=<tolerance in percent>,
+#             min_siginificant_digits=<number>, max_significant_digits=<number>)
+#         The tolerance is optional, and will default to the default tolerance specified above.
+#         The restrictions for the number of significant digits are optional as well.  Significant
+#         digits are counted started from the first non-zero digit specified by the student, and
+#         include trailing zeros.
+#
 #     String(answer='<correct answer>')
 table = [
     ['Carts', 'v_initial', 'v_final', 'Delta v'],


### PR DESCRIPTION
This implements the desired modifications, with the following deviations:
- The feature to accept only certain precisions is not implemented.
- Cells are not focused upon hovering, but instead an outline is shown in editable cells.
- Widths can be set for all columns individually.
- The "+help" looks visually different from the [model](http://dnextinteractives.s3.amazonaws.com/Calculus/taylor_expEtc.html). We can't guarantee that there is space for the button within the table, so we put it above the table.  The help text also appears above the table, and we must make the iframe big enough to accomodate the full expanded help text to avoid a scrollbar when activating the help.
